### PR TITLE
Move inactive maintainers to emeritus status

### DIFF
--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -4,4 +4,9 @@
 | name              | Github                                                 | Discord      |
 |-------------------|--------------------------------------------------------|--------------|
 | Alexander Zemtsov | [@zemtsov](https://github.com/zemtsov)                 | zemtsov#0819 |
+
+
+### Emeritus Maintainers
+| name              | Github                                                 | Discord      |
+|-------------------|--------------------------------------------------------|--------------|
 | Renat Gubaev      | [@ManhattanDoctor](https://github.com/ManhattanDoctor) |              |


### PR DESCRIPTION
The TSC approved a requirement that maintainers
that have not been active in over three to six
months be move to emeritus status.

These maintainers have not been active in over
one year.

https://github.com/hyperledger/toc/issues/32

Signed-off-by: Ry Jones <ry@linux.com>